### PR TITLE
Add STALE value to diagnostic_msgs/DiagnosticStatus/level enum

### DIFF
--- a/diagnostic_msgs/msg/DiagnosticStatus.msg
+++ b/diagnostic_msgs/msg/DiagnosticStatus.msg
@@ -5,6 +5,7 @@
 byte OK=0
 byte WARN=1
 byte ERROR=2
+byte STALE=3
 
 byte level # level of operation enumerated above 
 string name # a description of the test/component reporting


### PR DESCRIPTION
It appears it's become common to set diagnostic_msgs/DiagnosticStatus/level=3 to represent a "STALE" status.  Since this has become a convention, it makes sense to add this definition to the enum. 

See use of STALE status here: http://www.ros.org/doc/api/diagnostic_msgs/html/msg/DiagnosticStatus.html

See this answers thread for more info and discussion: http://answers.ros.org/question/47438/diagnostic_msgdiagnosticstatus-should-have-stale
