### PR TITLE
Added volatile to offset variable. 

### DIFF
--- a/sensor_msgs/include/sensor_msgs/point_cloud_conversion.h
+++ b/sensor_msgs/include/sensor_msgs/point_cloud_conversion.h
@@ -74,7 +74,7 @@ static inline bool convertPointCloudToPointCloud2 (const sensor_msgs::PointCloud
   output.fields.resize (3 + input.channels.size ());
   // Convert x/y/z to fields
   output.fields[0].name = "x"; output.fields[1].name = "y"; output.fields[2].name = "z";
-  int offset = 0;
+  volatile int offset = 0;
   // All offsets are *4, as all field data types are float32
   for (size_t d = 0; d < output.fields.size (); ++d, offset += 4)
   {


### PR DESCRIPTION
The crash was coming from optimization issues which is solved with volatile.
Possible source of this problem is a -ftrapv compilation flag I have.

Solution for issue:
https://github.com/ros/common_msgs/issues/6

Explanation copied from the above issue:
I've been running experiments with the tabletop_object_detector and found that the segmentation crashed. Those detection/segmentation nodes are passing pointclouds by sensor_msgs::PointCloud, not PointCloud2.
The bug always comes when sensor_msgs::convertPointCloudToPointCloud2() is called. I captured the point clouds that are being pushed to the converter at that time.

I set up a node that reproduces the bug. The code is the following:
http://pastebin.com/j6PUF2G7

Bag file with the data that produces the error: (~10MB)
https://www.dropbox.com/s/4fwc0d7d8vihsq0/points_cut2.bag
