### PR TITLE
Fix roslib import for message module, remove roslib.load_manifest

### DIFF
--- a/sensor_msgs/src/sensor_msgs/point_cloud2.py
+++ b/sensor_msgs/src/sensor_msgs/point_cloud2.py
@@ -40,12 +40,11 @@ Serialization of sensor_msgs.PointCloud2 messages.
 Author: Tim Field
 """
 
-import roslib; roslib.load_manifest('sensor_msgs')
-
 import ctypes
 import math
 import struct
 
+import roslib.message
 from sensor_msgs.msg import PointCloud2, PointField
 
 _DATATYPES = {}


### PR DESCRIPTION
The following code snippet fails with the current code base:

``` python
#!/usr/bin/python

from sensor_msgs.msg import PointCloud2
from sensor_msgs import point_cloud2

cloud = PointCloud2()
[[p[0], p[1], p[2], 1] for p in point_cloud2.read_points(cloud)]
```

points = [[p[0], p[1], p[2], 1] for p in point_cloud2.read_points(point_cloud)]
  File "/opt/ros/hydro/lib/python2.7/dist-packages/sensor_msgs/point_cloud2.py", line 74, in read_points
    assert isinstance(cloud, roslib.message.Message) and cloud._type == 'sensor_msgs/PointCloud2', 'cloud is not a sensor_msgs.msg.PointCloud2'
AttributeError: 'module' object has no attribute 'message'

---

I'm in the process of migrating the cluster based grasp planning to hydro and that uses the read_points function to convert the PointCloud2 message into a list of 3d points. This originally belonged to the pr2_object_manipulation stack which was deprecated with hydro.
