### PR TITLE
make link to control messages a real link

### DIFF
--- a/trajectory_msgs/package.xml
+++ b/trajectory_msgs/package.xml
@@ -3,7 +3,8 @@
   <version>1.10.3</version>
   <description>
     This package defines messages for defining robot trajectories. These messages are
-    also the building blocks of most of the control_msgs actions.
+    also the building blocks of most of the
+    <a href="http://wiki.ros.org/control_msgs">control_msgs</a> actions.
   </description>
   <maintainer email="tfoote@osrfoundation.org">Tully Foote</maintainer>
   <license>BSD</license>


### PR DESCRIPTION
This is based on how common_msgs links, so that it gets rendered nicely on the wiki.
