### PR TITLE
find_package(actionlib_msgs) mangles catkin_LIBRARIES variable

### DIFF
--- a/actionlib_msgs/cmake/actionlib_msgs-extras.cmake.em
+++ b/actionlib_msgs/cmake/actionlib_msgs-extras.cmake.em
@@ -1,5 +1,5 @@
 # need genmsg for _prepend_path()
-find_package(catkin REQUIRED COMPONENTS genmsg)
+find_package(genmsg REQUIRED)
 
 include(CMakeParseArguments)
 
@@ -46,6 +46,9 @@ macro(add_action_files)
   endif()
 
   foreach(actionfile ${FILES_W_PATH})
+    if(NOT CATKIN_DEVEL_PREFIX)
+      message(FATAL_ERROR "Assertion failed: 'CATKIN_DEVEL_PREFIX' is not set")
+    endif()
     get_filename_component(ACTION_SHORT_NAME ${actionfile} NAME_WE)
     set(MESSAGE_DIR ${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/msg)
     set(OUTPUT_FILES
@@ -63,6 +66,9 @@ macro(add_action_files)
 
     stamp(${actionfile})
 
+    if(NOT CATKIN_ENV)
+      message(FATAL_ERROR "Assertion failed: 'CATKIN_ENV' is not set")
+    endif()
     if(${actionfile} IS_NEWER_THAN ${MESSAGE_DIR}/${ACTION_SHORT_NAME}Action.msg)
       safe_execute_process(COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${GENACTION_BIN} ${actionfile} -o ${MESSAGE_DIR})
     endif()


### PR DESCRIPTION
Derived from ros/geometry#51:

The Hydro `actionlib_msgs` package mangles the catkin_LIBRARIES variable if it is included with `find_package(actionlib_msgs)`. The CMake extra file must not depend on catkin: https://github.com/ros/common_msgs/blob/hydro-devel/actionlib_msgs/cmake/actionlib_msgs-extras.cmake.em#L2
