### PR TITLE
use catkin_install_python() to install Python scripts

### DIFF
--- a/actionlib_msgs/CMakeLists.txt
+++ b/actionlib_msgs/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_package(
   CFG_EXTRAS actionlib_msgs-extras.cmake)
 
 # install the .action -> .msg generator
-install(PROGRAMS scripts/genaction.py
+catkin_install_python(PROGRAMS scripts/genaction.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 # install the legacy rosbuild cmake support

--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -14,7 +14,7 @@
   <url>http://ros.org/wiki/actionlib_msgs</url>
   <author>Vijay Pradeep</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>


### PR DESCRIPTION
While this is only necessary for _indigo_ it doesn't harm _hydro_.
