### PR TITLE
Add speech recognition msg

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -36,6 +36,7 @@ add_message_files(
   Range.msg
   RegionOfInterest.msg
   RelativeHumidity.msg
+  SpeechRecognitionCandidates.msg
   Temperature.msg
   TimeReference.msg)
 

--- a/sensor_msgs/msg/SpeechRecognitionCandidates.msg
+++ b/sensor_msgs/msg/SpeechRecognitionCandidates.msg
@@ -1,0 +1,2 @@
+string[] transcript
+float32[] confidence


### PR DESCRIPTION
I'd like to add SpeechRecognitionCandidates.msg to common_msgs, which includes two values:

```
string[] transcript   # candidate words of speech-to-text API
float32[] confidence # confidence of transcript
```

These are named after [W3C Web Speech API Specification](https://dvcs.w3.org/hg/speech-api/raw-file/9a0075d25326/speechapi.html) which is supported by Chrome.

This time I included this message in package sensor_msgs,
but, I cannot decide whether package to include this message in.
Now that, I think, more feature which is useful to robot using smart phone/tablet can appears such as  robot  app launcher, speech recognition, robot navigation controller apps.
Is it correct to include messages for such a "gui app" to sensor_msgs?
Should I make new package which is called something like "gui_msgs"?
