### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -22,4 +22,8 @@
   <run_depend>message_generation</run_depend> <!-- provide message generation to downstream packages -->
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/diagnostic_msgs/package.xml
+++ b/diagnostic_msgs/package.xml
@@ -26,4 +26,8 @@
 
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/geometry_msgs/package.xml
+++ b/geometry_msgs/package.xml
@@ -20,4 +20,8 @@
 
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/nav_msgs/package.xml
+++ b/nav_msgs/package.xml
@@ -22,4 +22,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>actionlib_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -19,4 +19,8 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/shape_msgs/package.xml
+++ b/shape_msgs/package.xml
@@ -20,4 +20,8 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/stereo_msgs/package.xml
+++ b/stereo_msgs/package.xml
@@ -20,4 +20,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>

--- a/trajectory_msgs/package.xml
+++ b/trajectory_msgs/package.xml
@@ -25,6 +25,7 @@
 
   <export>
     <rosbag_migration_rule rule_file="rules/JointTrajectoryPoint_Groovy2Hydro_08.10.2013.bmr" />
+    <architecture_independent/>
   </export>
 
 </package>

--- a/visualization_msgs/package.xml
+++ b/visualization_msgs/package.xml
@@ -24,4 +24,8 @@
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+
+  <export>
+    <architecture_independent/>
+  </export>
 </package>


### PR DESCRIPTION
These packages don't have any binaries in them, so they can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
