### PR TITLE
Added comment to document new Rviz Marker action

### DIFF
--- a/visualization_msgs/msg/Marker.msg
+++ b/visualization_msgs/msg/Marker.msg
@@ -22,7 +22,7 @@ Header header                        # header for time/frame information
 string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object
 int32 id 		                         # object ID useful in conjunction with the namespace for manipulating and deleting the object later
 int32 type 		                       # Type of object
-int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object
+int32 action 	                       # 0 add/modify an object, 1 (deprecated), 2 deletes an object, 3 deletes all objects
 geometry_msgs/Pose pose                 # Pose of the object
 geometry_msgs/Vector3 scale             # Scale of the object 1,1,1 means default (usually 1 meter square)
 std_msgs/ColorRGBA color             # Color [0.0-1.0]

--- a/visualization_msgs/msg/Marker.msg
+++ b/visualization_msgs/msg/Marker.msg
@@ -16,6 +16,7 @@ uint8 TRIANGLE_LIST=11
 uint8 ADD=0
 uint8 MODIFY=0
 uint8 DELETE=2
+#uint8 DELETEALL=3 # TODO: enable for ROS-J, disabled for now but functionality is still there. Allows one to clear all markers in plugin
 
 Header header                        # header for time/frame information
 string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object


### PR DESCRIPTION
This does not change the MD5 sum of common_msgs, but merely documents a new feature that can be optionally used.

I do advocate we enable this action type in ROS-J. 

This change documents https://github.com/ros-visualization/rviz/pull/781
