### PR TITLE
fix critical bug with operator+

### DIFF
--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.h
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.h
@@ -322,7 +322,7 @@ PointCloud2IteratorBase<T, U> PointCloud2IteratorBase<T, U>::operator +(int i)
   PointCloud2IteratorBase<T, U> res = *this;
 
   res.data_char_ += i*point_step_;
-  res.data_ = reinterpret_cast<T*>(data_char_);
+  res.data_ = reinterpret_cast<T*>(res.data_char_);
 
   return res;
 }


### PR DESCRIPTION
The operator+ doesn't actually increment, since it references the wrong data_char_ (the non-incremented one). This was found while debugging https://github.com/ros-planning/moveit_ros/issues/505
