### PR TITLE
Adds a SetMap service message to support swap maps functionality in amcl

### DIFF
--- a/nav_msgs/CMakeLists.txt
+++ b/nav_msgs/CMakeLists.txt
@@ -16,7 +16,8 @@ add_service_files(
   DIRECTORY srv
   FILES
   GetMap.srv
-  GetPlan.srv)
+  GetPlan.srv
+  SetMap.srv)
 
 add_action_files(
   FILES

--- a/nav_msgs/srv/SetMap.srv
+++ b/nav_msgs/srv/SetMap.srv
@@ -1,0 +1,5 @@
+ nav_msgs/OccupancyGrid map
+ geometry_msgs/Pose initial_pose
+ ---
+ bool success
+


### PR DESCRIPTION
This supports the addition of a new service to amcl which allows the map to be changed and an initial pose set in one action. https://github.com/ros-planning/navigation/pull/301
