### PR TITLE
Adds a SetMap service message to support swap maps functionality in amcl

### DIFF
--- a/nav_msgs/CMakeLists.txt
+++ b/nav_msgs/CMakeLists.txt
@@ -16,7 +16,8 @@ add_service_files(
   DIRECTORY srv
   FILES
   GetMap.srv
-  GetPlan.srv)
+  GetPlan.srv
+  SetMap.srv)
 
 add_action_files(
   FILES

--- a/nav_msgs/srv/SetMap.srv
+++ b/nav_msgs/srv/SetMap.srv
@@ -1,5 +1,6 @@
- nav_msgs/OccupancyGrid map
- geometry_msgs/Pose initial_pose
- ---
- bool success
+# Set a new map together with an initial pose
+nav_msgs/OccupancyGrid map
+geometry_msgs/PoseWithCovarianceStamped initial_pose
+---
+bool success
 

--- a/nav_msgs/srv/SetMap.srv
+++ b/nav_msgs/srv/SetMap.srv
@@ -1,0 +1,5 @@
+ nav_msgs/OccupancyGrid map
+ geometry_msgs/Pose initial_pose
+ ---
+ bool success
+


### PR DESCRIPTION
This is a backport of 04cceab to indigo.

@liz-murphy @mikeferguson @tfoote I just noticed that the `initial_pose` should rather be a `PoseWithCovarianceStamped` to support passing the covariance, analogue to amcl's topic `/initial_pose`. What do you think? The idea behind this new service was to get the same as publishing a new map and a new initial pose but with the feedback from the handler of those messages to make sure they actually arrived and are in use.
