### PR TITLE
Add a battery state message

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(include)
 add_message_files(
   DIRECTORY msg
   FILES
+  BatteryState.msg
   CameraInfo.msg
   ChannelFloat32.msg
   CompressedImage.msg

--- a/sensor_msgs/msg/BatteryState.msg
+++ b/sensor_msgs/msg/BatteryState.msg
@@ -1,0 +1,49 @@
+
+# Constants are chosen to match the enums in the linux kernel
+# defined in include/linux/power_supply.h as of version 3.7
+# The one difference is for style reasons the constants are
+# all uppercase not mixed case.
+
+# Power supply status constants
+uint8 POWER_SUPPLY_STATUS_UNKNOWN = 0
+uint8 POWER_SUPPLY_STATUS_CHARGING = 1
+uint8 POWER_SUPPLY_STATUS_DISCHARGING = 2
+uint8 POWER_SUPPLY_STATUS_NOT_CHARGING = 3
+uint8 POWER_SUPPLY_STATUS_FULL = 4
+
+# Power supply health constants
+uint8 POWER_SUPPLY_HEALTH_UNKNOWN = 0
+uint8 POWER_SUPPLY_HEALTH_GOOD = 1
+uint8 POWER_SUPPLY_HEALTH_OVERHEAT = 2
+uint8 POWER_SUPPLY_HEALTH_DEAD = 3
+uint8 POWER_SUPPLY_HEALTH_OVERVOLTAGE = 4
+uint8 POWER_SUPPLY_HEALTH_UNSPEC_FAILURE = 5
+uint8 POWER_SUPPLY_HEALTH_COLD = 6
+uint8 POWER_SUPPLY_HEALTH_WATCHDOG_TIMER_EXPIRE = 7
+uint8 POWER_SUPPLY_HEALTH_SAFETY_TIMER_EXPIRE = 8
+
+# Power supply technology (chemistry) constants
+uint8 POWER_SUPPLY_TECHNOLOGY_UNKNOWN = 0
+uint8 POWER_SUPPLY_TECHNOLOGY_NIMH = 1
+uint8 POWER_SUPPLY_TECHNOLOGY_LION = 2
+uint8 POWER_SUPPLY_TECHNOLOGY_LIPO = 3
+uint8 POWER_SUPPLY_TECHNOLOGY_LIFE = 4
+uint8 POWER_SUPPLY_TECHNOLOGY_NICD = 5
+uint8 POWER_SUPPLY_TECHNOLOGY_LIMN = 6
+
+Header  header
+float32 voltage          # Voltage in Volts (Mandatory)
+float32 current          # Negative when discharging (A)  (If unmeasured NaN)
+float32 charge           # Current charge in Ah  (If unmeasured NaN)
+float32 capacity         # Capacity in Ah (last full capacity)  (If unmeasured NaN)
+float32 design_capacity  # Capacity in Ah (design capacity)  (If unmeasured NaN)
+float32 percentage       # Charge percentage on 0 to 1 range  (If unmeasured NaN)
+uint8   power_supply_status     # The charging status as reported. Values defined above
+uint8   power_supply_health     # The battery health metric. Values defined above
+uint8   power_supply_technology # The battery chemistry. Values defined above
+bool    present          # True if the battery is present
+
+float32[] cell_voltage   # An array of individual cell voltages for each cell in the pack
+                         # If individual voltages unknown but number of cells known set each to NaN
+string location          # The location into which the battery is inserted. (slot number or plug)
+string serial_number     # The best approximation of the battery serial number


### PR DESCRIPTION
This has come from the ROS SIG Mav reviews looking for a smart battery message. https://groups.google.com/forum/#!topic/ros-sig-mav/f12m3mnqYl4

This is an iteration on [linux_hardware/LaptopChargeStatus.msg](http://docs.ros.org/hydro/api/linux_hardware/html/msg/LaptopChargeStatus.html) 

There's another similar message here: https://github.com/ros-drivers/smart_battery_msgs/blob/master/msg/SmartBatteryStatus.msg

This assumes a smart battery. Smart batteries are becoming ubiquitous in next generations UAVs and we expect many more to become available in other domains as well. 

To support non-smart batteries the only mandatory field is the voltage. All other fields have documented undefined values. 

We added support for multi-cell information as well as a string for location and serial numbers. 

@mikeferguson Would you consider using this for here: https://github.com/fetchrobotics/power_msgs/issues/3 The one thing I don't see here is the time remaining estimate. 
