### PR TITLE
sensor_msgs: Generate optimal msg lentgth when both "xyz" and "rgb(a)…

### DIFF
--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.h
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.h
@@ -201,6 +201,8 @@ inline void PointCloud2Modifier::setPointCloud2FieldsByString(int n_fields, ...)
   va_list vl;
   va_start(vl, n_fields);
   int offset = 0;
+  bool has_xyz = false;
+  bool has_rgb = false;
   for (int i = 0; i < n_fields; ++i) {
     // Create the corresponding PointFields
     std::string
@@ -211,15 +213,20 @@ inline void PointCloud2Modifier::setPointCloud2FieldsByString(int n_fields, ...)
       offset = addPointField(cloud_msg_, "x", 1, sensor_msgs::PointField::FLOAT32, offset);
       offset = addPointField(cloud_msg_, "y", 1, sensor_msgs::PointField::FLOAT32, offset);
       offset = addPointField(cloud_msg_, "z", 1, sensor_msgs::PointField::FLOAT32, offset);
-      offset += sizeOfPointField(sensor_msgs::PointField::FLOAT32);
+      has_xyz = true;
     } else
       if ((field_name == "rgb") || (field_name == "rgba")) {
         offset = addPointField(cloud_msg_, field_name, 1, sensor_msgs::PointField::FLOAT32, offset);
-        offset += 3 * sizeOfPointField(sensor_msgs::PointField::FLOAT32);
+        has_rgb = true;
       } else
         throw std::runtime_error("Field " + field_name + " does not exist");
   }
   va_end(vl);
+
+  if (has_xyz && !has_rgb)
+    offset += sizeOfPointField(sensor_msgs::PointField::FLOAT32);
+  else if (!has_xyz && has_rgb)
+    offset += 3 * sizeOfPointField(sensor_msgs::PointField::FLOAT32);
 
   // Resize the point cloud accordingly
   cloud_msg_.point_step = offset;

--- a/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.h
+++ b/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.h
@@ -189,7 +189,7 @@ inline void PointCloud2Modifier::setPointCloud2Fields(int n_fields, ...)
  *        internals of the PointCloud2
  * @param n_fields the number of fields to add. The fields are given as
  *        strings: "xyz" (3 floats), "rgb" (3 uchar stacked in a float),
- *        "rgba" (4 uchar stacked in a float)
+ *        "rgba" (4 uchar stacked in a uint32)
  * @return void
  *
  * WARNING: THIS FUNCTION DOES ADD ANY NECESSARY PADDING TRANSPARENTLY
@@ -215,8 +215,11 @@ inline void PointCloud2Modifier::setPointCloud2FieldsByString(int n_fields, ...)
       offset = addPointField(cloud_msg_, "z", 1, sensor_msgs::PointField::FLOAT32, offset);
       has_xyz = true;
     } else
-      if ((field_name == "rgb") || (field_name == "rgba")) {
+      if (field_name == "rgb") {
         offset = addPointField(cloud_msg_, field_name, 1, sensor_msgs::PointField::FLOAT32, offset);
+        has_rgb = true;
+      } else if (field_name == "rgba") {
+        offset = addPointField(cloud_msg_, field_name, 1, sensor_msgs::PointField::UINT32, offset);
         has_rgb = true;
       } else
         throw std::runtime_error("Field " + field_name + " does not exist");


### PR DESCRIPTION
…" are given to PointCloud2Modifier.

With this patch PointCloud2Modifier::setPointCloud2FieldsByString make PointCloud2 message with an optimal length by **removing unnecessary trailling offset without messing with the padding**. It cut in half the msg length.

When we used something like in https://github.com/ros-perception/image_pipeline/blob/indigo/depth_image_proc/src/nodelets/point_cloud_xyzrgb.cpp#L251

``` cpp
     sensor_msgs::PointCloud2Modifier pcd_modifier(*cloud_msg);
     pcd_modifier.setPointCloud2FieldsByString(2, "xyz", "rgb"); 
```

By exemple, with kinect images the cloud msg length was 9.83MB. Now it's 4.92MB, like with just the xyz part.

Since it's a core library every project that depends on it should be recompiled.
