### PR TITLE
Deal with abstarct image encodings like 8UC40 and 8UC

### DIFF
--- a/sensor_msgs/include/sensor_msgs/image_encodings.h
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.h
@@ -209,24 +209,28 @@ namespace sensor_msgs
           encoding == BAYER_GRBG16)
         return 16;
 
-      // B = bits (8, 16, ...), T = type (U, S, F)
-#define CHECK_BIT_DEPTH(B, T)                   \
-      if (encoding == TYPE_##B##T##C1 ||        \
-          encoding == TYPE_##B##T##C2 ||        \
-          encoding == TYPE_##B##T##C3 ||        \
-          encoding == TYPE_##B##T##C4)          \
-        return B;                               \
-      /***/
-
-      CHECK_BIT_DEPTH(8, U);
-      CHECK_BIT_DEPTH(8, S);
-      CHECK_BIT_DEPTH(16, U);
-      CHECK_BIT_DEPTH(16, S);
-      CHECK_BIT_DEPTH(32, S);
-      CHECK_BIT_DEPTH(32, F);
-      CHECK_BIT_DEPTH(64, F);
-
-#undef CHECK_BIT_DEPTH
+      // Now all the generic content encodings
+      // TODO: Rewrite with regex when ROS supports C++11
+      std::vector<std::string> prefixes;
+      prefixes.push_back("8UC");
+      prefixes.push_back("8SC");
+      prefixes.push_back("16UC");
+      prefixes.push_back("16SC");
+      prefixes.push_back("32SC");
+      prefixes.push_back("32FC");
+      prefixes.push_back("64FC");
+      for (size_t i=0; i < prefixes.size(); i++)
+      {
+        std::string prefix = prefixes[i];
+        if (encoding.substr(0, prefix.size()) != prefix)
+          continue;
+        if (encoding.size() == prefix.size())
+          return atoi(prefix.c_str());  // ex. 8UC -> 8
+        int n_channel = atoi(encoding.substr(prefix.size(),
+                                             encoding.size() - prefix.size()).c_str());  // ex. 8UC10 -> 10
+        if (n_channel != 0)
+          return atoi(prefix.c_str());  // valid encoding string
+      }
 
       if (encoding == YUV422)
         return 8;

--- a/sensor_msgs/include/sensor_msgs/image_encodings.h
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.h
@@ -99,6 +99,10 @@ namespace sensor_msgs
     // with an 8-bit depth
     const std::string YUV422="yuv422";
 
+    // Prefixes for abstract image encodings
+    const std::string ABSTRACT_ENCODING_PREFIXES[] = {
+        "8UC", "8SC", "16UC", "16SC", "32SC", "32FC", "64FC"};
+
     // Utility functions for inspecting an encoding string
     static inline bool isColor(const std::string& encoding)
     {
@@ -155,17 +159,9 @@ namespace sensor_msgs
 
       // Now all the generic content encodings
       // TODO: Rewrite with regex when ROS supports C++11
-      std::vector<std::string> prefixes;
-      prefixes.push_back("8UC");
-      prefixes.push_back("8SC");
-      prefixes.push_back("16UC");
-      prefixes.push_back("16SC");
-      prefixes.push_back("32SC");
-      prefixes.push_back("32FC");
-      prefixes.push_back("64FC");
-      for (size_t i=0; i < prefixes.size(); i++)
+      for (size_t i=0; i < sizeof(ABSTRACT_ENCODING_PREFIXES) / sizeof(*ABSTRACT_ENCODING_PREFIXES); i++)
       {
-        std::string prefix = prefixes[i];
+        std::string prefix = ABSTRACT_ENCODING_PREFIXES[i];
         if (encoding.substr(0, prefix.size()) != prefix)
           continue;
         if (encoding.size() == prefix.size())
@@ -211,17 +207,9 @@ namespace sensor_msgs
 
       // Now all the generic content encodings
       // TODO: Rewrite with regex when ROS supports C++11
-      std::vector<std::string> prefixes;
-      prefixes.push_back("8UC");
-      prefixes.push_back("8SC");
-      prefixes.push_back("16UC");
-      prefixes.push_back("16SC");
-      prefixes.push_back("32SC");
-      prefixes.push_back("32FC");
-      prefixes.push_back("64FC");
-      for (size_t i=0; i < prefixes.size(); i++)
+      for (size_t i=0; i < sizeof(ABSTRACT_ENCODING_PREFIXES) / sizeof(*ABSTRACT_ENCODING_PREFIXES); i++)
       {
-        std::string prefix = prefixes[i];
+        std::string prefix = ABSTRACT_ENCODING_PREFIXES[i];
         if (encoding.substr(0, prefix.size()) != prefix)
           continue;
         if (encoding.size() == prefix.size())

--- a/sensor_msgs/include/sensor_msgs/image_encodings.h
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.h
@@ -154,23 +154,27 @@ namespace sensor_msgs
         return 1;
 
       // Now all the generic content encodings
-#define CHECK_CHANNELS(N)                       \
-      if (encoding == TYPE_8UC##N  ||           \
-          encoding == TYPE_8SC##N  ||           \
-          encoding == TYPE_16UC##N ||           \
-          encoding == TYPE_16SC##N ||           \
-          encoding == TYPE_32SC##N ||           \
-          encoding == TYPE_32FC##N ||           \
-          encoding == TYPE_64FC##N)             \
-        return N;                               \
-      /***/
-      
-      CHECK_CHANNELS(1);
-      CHECK_CHANNELS(2);
-      CHECK_CHANNELS(3);
-      CHECK_CHANNELS(4);
-
-#undef CHECK_CHANNELS
+      // TODO: Rewrite with regex when ROS supports C++11
+      std::vector<std::string> prefixes;
+      prefixes.push_back("8UC");
+      prefixes.push_back("8SC");
+      prefixes.push_back("16UC");
+      prefixes.push_back("16SC");
+      prefixes.push_back("32SC");
+      prefixes.push_back("32FC");
+      prefixes.push_back("64FC");
+      for (size_t i=0; i < prefixes.size(); i++)
+      {
+        std::string prefix = prefixes[i];
+        if (encoding.substr(0, prefix.size()) != prefix)
+          continue;
+        if (encoding.size() == prefix.size())
+          return 1;  // ex. 8UC -> 1
+        int n_channel = atoi(encoding.substr(prefix.size(),
+                                             encoding.size() - prefix.size()).c_str());  // ex. 8UC5 -> 5
+        if (n_channel != 0)
+          return n_channel;  // valid encoding string
+      }
 
       if (encoding == YUV422)
         return 2;

--- a/sensor_msgs/test/CMakeLists.txt
+++ b/sensor_msgs/test/CMakeLists.txt
@@ -1,2 +1,3 @@
 include_directories(${catkin_INCLUDE_DIRS})
 catkin_add_gtest(sensor_msgs_test main.cpp)
+catkin_add_gtest(sensor_msgs_test_image_encodings test_image_encodings.cpp)

--- a/sensor_msgs/test/test_image_encodings.cpp
+++ b/sensor_msgs/test/test_image_encodings.cpp
@@ -54,6 +54,24 @@ TEST(sensor_msgs, NumChannels)
   ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC10"), 10);
 }
 
+TEST(sensor_msgs, bitDepth)
+{
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("mono8"), 8);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("rgb8"), 8);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("8UC"), 8);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("8UC3"), 8);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("8UC10"), 8);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("16UC"), 16);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("16UC3"), 16);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("16UC10"), 16);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("32SC"), 32);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("32SC3"), 32);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("32SC10"), 32);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("64FC"), 64);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("64FC3"), 64);
+  ASSERT_EQ(sensor_msgs::image_encodings::bitDepth("64FC10"), 64);
+}
+
 int main(int argc, char** argv)
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/sensor_msgs/test/test_image_encodings.cpp
+++ b/sensor_msgs/test/test_image_encodings.cpp
@@ -1,0 +1,61 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2016, Kentaro Wada.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <sensor_msgs/image_encodings.h>
+
+TEST(sensor_msgs, NumChannels)
+{
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("mono8"), 1);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("rgb8"), 3);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("8UC"), 1);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("8UC3"), 3);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("8UC10"), 10);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("16UC"), 1);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("16UC3"), 3);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("16UC10"), 10);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("32SC"), 1);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("32SC3"), 3);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("32SC10"), 10);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC"), 1);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC3"), 3);
+  ASSERT_EQ(sensor_msgs::image_encodings::numChannels("64FC10"), 10);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is for https://github.com/ros-perception/vision_opencv/pull/150, and suggested by @vrabaud at https://github.com/ros-perception/vision_opencv/pull/150#issuecomment-246205371 .
