### PR TITLE
Add LoadMap service

### DIFF
--- a/nav_msgs/srv/LoadMap.srv
+++ b/nav_msgs/srv/LoadMap.srv
@@ -1,0 +1,3 @@
+string map_path
+---
+bool success


### PR DESCRIPTION
The Load map service is to be handled by map_server. It will load (or reload) a map from the given file path when called.

This would allow completion of pull request ros-planning/navigation#461
Which would close ros-planning/navigation#279
