### PR TITLE
Add LoadMap service

### DIFF
--- a/nav_msgs/CMakeLists.txt
+++ b/nav_msgs/CMakeLists.txt
@@ -17,7 +17,8 @@ add_service_files(
   FILES
   GetMap.srv
   GetPlan.srv
-  SetMap.srv)
+  SetMap.srv
+  LoadMap.srv)
 
 add_action_files(
   FILES

--- a/nav_msgs/srv/LoadMap.srv
+++ b/nav_msgs/srv/LoadMap.srv
@@ -1,0 +1,13 @@
+# Result code defintions
+uint8 RESULT_SUCCESS=0
+uint8 RESULT_MAP_DOES_NOT_EXIST=1
+uint8 RESULT_INVALID_MAP_DATA=2
+uint8 RESULT_INVALID_MAP_METADATA=2
+uint8 RESULT_UNDEFINED_FAILURE=255
+
+# ID of map resource
+string map_id
+---
+# Returned map is only valid if result equals RESULT_SUCCESS
+nav_msgs/OccupancyGrid map
+uint8 result


### PR DESCRIPTION
The service is for loading a map as an [nav_msgs/OccupancyGrid](http://docs.ros.org/indigo/api/nav_msgs/html/msg/OccupancyGrid.html) given a resource ID. It also features a **result** member to encode errors. I tried to make the result codes generic enough for support of arbitrary backends and underlying data structures.   

This could be implemented in a *map_loader* node or directly in [map_server](https://github.com/ros-planning/navigation) seeing how it already "loads" a map on startup.