### PR TITLE
actionlib_msgs: add_action_files takes absolute paths for DIRECTORY a…

### DIFF
--- a/actionlib_msgs/cmake/actionlib_msgs-extras.cmake.em
+++ b/actionlib_msgs/cmake/actionlib_msgs-extras.cmake.em
@@ -21,8 +21,9 @@ macro(add_action_files)
     set(ARG_DIRECTORY "action")
   endif()
 
-  if(NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY})
-    message(FATAL_ERROR "add_action_files() directory not found: ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY}")
+  set(ACTION_DIR "${ARG_DIRECTORY}")
+  if(NOT IS_ABSOLUTE "${ACTION_DIR}")
+    set(ACTION_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${ACTION_DIR}")
   endif()
 
   # if FILES are not passed search action files in the given directory
@@ -30,10 +31,10 @@ macro(add_action_files)
   set(_argv ${ARGV})
   list(FIND _argv "FILES" _index)
   if(_index EQUAL -1)
-    file(GLOB ARG_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY}" "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY}/*.action")
+    file(GLOB ARG_FILES RELATIVE "${ACTION_DIR}" "${ACTION_DIR}/*.action")
     list(SORT ARG_FILES)
   endif()
-  _prepend_path(${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY} "${ARG_FILES}" FILES_W_PATH)
+  _prepend_path(${ACTION_DIR} "${ARG_FILES}" FILES_W_PATH)
 
   list(APPEND ${PROJECT_NAME}_ACTION_FILES ${FILES_W_PATH})
   foreach(file ${FILES_W_PATH})
@@ -41,7 +42,11 @@ macro(add_action_files)
   endforeach()
 
   if(NOT ARG_NOINSTALL)
-    install(FILES ${FILES_W_PATH} DESTINATION share/${PROJECT_NAME}/${ARG_DIRECTORY})
+    # ensure that destination variables are initialized
+    catkin_destinations()
+
+    install(FILES ${FILES_W_PATH}
+      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${ARG_DIRECTORY})
   endif()
 
   foreach(actionfile ${FILES_W_PATH})
@@ -73,7 +78,7 @@ macro(add_action_files)
     endif()
 
     add_message_files(
-      BASE_DIR ${MESSAGE_DIR}
+      DIRECTORY ${MESSAGE_DIR}
       FILES ${OUTPUT_FILES})
   endforeach()
 endmacro()

--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 
+  <build_depend version_gte="0.5.4">genmsg</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
 


### PR DESCRIPTION
…rgument. This matches behavior of add_message_files and add_service_files. It implements in jade-devel the functionality of seemingly-abandoned PR ros/common_msgs#43.

Note that the .action file install path was updated to match messages and services, however that means that absolute DIRECTORY paths are installed relative to CATKIN_PACKAGE_SHARE_DESTINATION (ie, /usr/src/myactionfiles ends up in /opt/ros/jade/share/mypackage/usr/src/myactionfiles). Not sure if this is desired behavior or a bug.