### PR TITLE
fix catkin_lint warnings

### DIFF
--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -20,6 +20,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
 
+  <test_depend>rosunit</test_depend>
+
   <export>
     <architecture_independent/>
   </export>

--- a/sensor_msgs/test/CMakeLists.txt
+++ b/sensor_msgs/test/CMakeLists.txt
@@ -1,3 +1,3 @@
 include_directories(${catkin_INCLUDE_DIRS})
-catkin_add_gtest(sensor_msgs_test main.cpp)
-catkin_add_gtest(sensor_msgs_test_image_encodings test_image_encodings.cpp)
+catkin_add_gtest(${PROJECT_NAME}_test main.cpp)
+catkin_add_gtest(${PROJECT_NAME}_test_image_encodings test_image_encodings.cpp)


### PR DESCRIPTION
This PR remove several warning of catkin_lint, we still have following 'notice'. But I do not have good idea.
See #102

```
k-okada@p40-yoga:~/catkin_ws/ws_migration/src/common_msgs/sensor_msgs$ catkin_lint -W2
sensor_msgs: notice: package description starts with boilerplate 'This package'
catkin_lint: checked 1 packages and found 1 problems
```