### PR TITLE
Image/PointCloud Snapshot as a service

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -43,7 +43,8 @@ add_service_files(
   DIRECTORY srv
   FILES 
   SetCameraInfo.srv
-  SnapshotCloud.srv)
+  SnapshotCloud.srv
+  SnapshotImage.srv)
 
 generate_messages(DEPENDENCIES geometry_msgs std_msgs)
 

--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(sensor_msgs)
 
-find_package(catkin REQUIRED COMPONENTS geometry_msgs message_generation std_msgs)
+find_package(catkin REQUIRED COMPONENTS geometry_msgs actionlib_msgs message_generation std_msgs)
 
 # For point_cloud2.py
 catkin_python_setup()
@@ -46,7 +46,13 @@ add_service_files(
   SnapshotCloud.srv
   SnapshotImage.srv)
 
-generate_messages(DEPENDENCIES geometry_msgs std_msgs)
+add_action_files(
+  DIRECTORY action
+  FILES
+  AdvancedSnapshotCloud.action
+)
+
+generate_messages(DEPENDENCIES geometry_msgs std_msgs actionlib_msgs)
 
 catkin_package(
   INCLUDE_DIRS include

--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -41,7 +41,9 @@ add_message_files(
 
 add_service_files(
   DIRECTORY srv
-  FILES SetCameraInfo.srv)
+  FILES 
+  SetCameraInfo.srv
+  SnapshotCloud.srv)
 
 generate_messages(DEPENDENCIES geometry_msgs std_msgs)
 

--- a/sensor_msgs/action/AdvancedSnapshotCloud.action
+++ b/sensor_msgs/action/AdvancedSnapshotCloud.action
@@ -4,7 +4,10 @@ bool dense_cloud
 # exposure in milliseconds (0 indicates autoexposure)
 uint32 exposure
 
-bool raw_data
+uint8 raw_data
+uint8 NO_RAW_DATA = 0
+uint8 GRAYSCALE = 1
+uint8 RGB = 2
 
 ---
 

--- a/sensor_msgs/action/AdvancedSnapshotCloud.action
+++ b/sensor_msgs/action/AdvancedSnapshotCloud.action
@@ -1,0 +1,19 @@
+# dense_cloud = true, if the cloud has to be dense (ordered)
+bool dense_cloud
+
+# exposure in milliseconds (0 indicates autoexposure)
+uint32 exposure
+
+bool raw_data
+
+---
+
+# cloud is the returning point cloud
+sensor_msgs/PointCloud2 cloud
+
+# image is the 2d data form the camera
+sensor_msgs/Image image
+
+---
+
+uint32 percentage_completed

--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -15,10 +15,12 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
 
   <export>
     <architecture_independent/>

--- a/sensor_msgs/srv/SnapshotCloud.srv
+++ b/sensor_msgs/srv/SnapshotCloud.srv
@@ -1,0 +1,14 @@
+#Request/Reply for Point Cloud as a service
+
+# Request:
+#   dense_cloud = true if the cloud has to be dense (ordered)
+#   exposure in milliseconds (0 indicates autoexposure) 
+bool dense_cloud
+uint32 exposure
+
+---
+
+# Reply:
+#   cloud is the returning point cloud
+sensor_msgs/PointCloud2 cloud 
+

--- a/sensor_msgs/srv/SnapshotCloud.srv
+++ b/sensor_msgs/srv/SnapshotCloud.srv
@@ -1,14 +1,17 @@
-#Request/Reply for Point Cloud as a service
+# Point Cloud as a service
 
-# Request:
-#   dense_cloud = true if the cloud has to be dense (ordered)
-#   exposure in milliseconds (0 indicates autoexposure) 
+# REQUEST:
+
+# dense_cloud = true, if the cloud has to be dense (ordered)
 bool dense_cloud
+
+# exposure in milliseconds (0 indicates autoexposure) 
 uint32 exposure
 
 ---
 
-# Reply:
-#   cloud is the returning point cloud
+# RESPONSE:
+
+# cloud is the returning point cloud
 sensor_msgs/PointCloud2 cloud 
 

--- a/sensor_msgs/srv/SnapshotImage.srv
+++ b/sensor_msgs/srv/SnapshotImage.srv
@@ -1,0 +1,17 @@
+# Image as a service
+
+# REQUEST
+
+# exposure in milliseconds (0 indicates autoexposure) 
+uint32 exposure
+
+---
+
+# RESPONSE:
+
+# image is the returning raw image
+sensor_msgs/Image image
+
+# camera info, which includes intrinsics calibration
+sensor_msgs/CameraInfo camera_info
+


### PR DESCRIPTION
Some applications, such as industrial manipulation, do not require image/point_cloud streaming. Instead, they need image/point_cloud as a service, upon a request of some other client node, thus networking load is reduced, allowing other hardware to work better (specially that involving controllers).

This Pull Request defines image and point cloud snapshots as services. Examples of packages using these services can be found at: 
- [PtGrey BlackFly Monocular camera](https://github.com/beta-robots/ptgrey_bfly_camera)
- [Ensenso 3D camera ](https://github.com/beta-robots/ensenso_nx)

The Pull Request is against jade-devel branch because it is the latest one available, but the services have been tested on kinetic. However, it seems that they could work on jade and indigo. 