### PR TITLE
Added test_depend on rosunit in sensor_msgs

### DIFF
--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -20,6 +20,8 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>std_msgs</run_depend>
 
+  <test_depend>rosunit</test_depend>
+
   <export>
     <architecture_independent/>
   </export>


### PR DESCRIPTION
I noticed that this dependency was missing in sensor_msgs, which uses gtest. This is contrary to 
http://docs.ros.org/jade/api/catkin/html/howto/format1/gtest_configuration.html.

See also #85 