### PR TITLE
[sensor_msgs] Return true in isMono for 8UC and 16UC

### DIFF
--- a/sensor_msgs/include/sensor_msgs/image_encodings.h
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.h
@@ -115,7 +115,9 @@ namespace sensor_msgs
 
     static inline bool isMono(const std::string& encoding)
     {
-      return encoding == MONO8 || encoding == MONO16;
+      return encoding == MONO8 || encoding == MONO16 ||
+             encoding == "8UC" || encoding == "8UC1" ||
+             encoding == "16UC" || encoding == "16UC1";
     }
 
     static inline bool isBayer(const std::string& encoding)


### PR DESCRIPTION
This is needed in conversion from 8UC1 image msg to mono8 image.
Requested by https://github.com/ros-perception/vision_opencv/issues/175