### PR TITLE
Support for dynamic PointCloud2 creation

### DIFF
--- a/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
+++ b/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
@@ -315,10 +315,29 @@ public:
    */
   V<T>& operator +=(int i);
 
+  /**
+   * Organized point cloud access, access the iterator at the associated position (column, row), where 0 <= column < width
+   * and 0 <= row <= height.
+   * @param column The column in which the iterator should be accessed, iterator at (column, row)
+   * @param row The row in whcih the iterator should be accessed, iterator at (column, row)
+   * @return an iterator at (column, row)
+   */
+  V<T>& operator ()(int column, int row);
+
   /** Compare to another iterator
    * @return whether the current iterator points to a different address than the other one
    */
   bool operator !=(const V<T>& iter) const;
+
+  /** Reset to start
+   * @return Resets the iterator to the start
+   */
+  V<T>& reset();
+
+  /** Return the start iterator
+   * @return the start iterator
+   */
+  V<T> start() const;
 
   /** Return the end iterator
    * @return the end iterator (useful when performing normal iterator processing with ++)
@@ -335,12 +354,18 @@ private:
 
   /** The "point_step" of the original cloud */
   int point_step_;
+  /** The "width" of the original cloud */
+  int width;
+  /** The "height" of the original cloud */
+  int height;
   /** The raw data  in uchar* where the iterator is */
   U* data_char_;
   /** The cast data where the iterator is */
   TT* data_;
   /** The end() pointer of the iterator */
   TT* data_end_;
+  /** pointer to first value in field */
+  U* data_begin_;
   /** Whether the fields are stored as bigendian */
   bool is_bigendian_;
 };

--- a/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
+++ b/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
@@ -161,9 +161,23 @@ public:
    * WARNING: THIS FUNCTION DOES ADD ANY NECESSARY PADDING TRANSPARENTLY
    */
   void setPointCloud2FieldsByString(int n_fields, ...);
+
+  class PointFieldInfo{
+    public:
+      PointFieldInfo(std::string name, std::string datatype)
+         : name(name), datatype(datatype){}
+      std::string name;
+      std::string datatype;
+  };
+
+  void addPointCloud2Fields(std::vector<PointFieldInfo> fields);
+  bool addPointCloud2Field(std::string name, std::string datatype);
+
 protected:
   /** A reference to the original sensor_msgs::PointCloud2 that we read */
   PointCloud2& cloud_msg_;
+    /** The current offset for all point fields */
+  int current_offset_;
 };
 
 namespace impl

--- a/sensor_msgs/include/sensor_msgs/point_cloud_conversion.h
+++ b/sensor_msgs/include/sensor_msgs/point_cloud_conversion.h
@@ -41,6 +41,7 @@
 #include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/point_field_conversion.h>
+#include <algorithm>
 
 /** 
   * \brief Convert between the old (sensor_msgs::PointCloud) and the new (sensor_msgs::PointCloud2) format.
@@ -60,6 +61,11 @@ static inline int getPointCloud2FieldIndex (const sensor_msgs::PointCloud2 &clou
     if (cloud.fields[d].name == field_name)
       return (d);
   return (-1);
+}
+
+static inline bool hasPointCloud2Field (const sensor_msgs::PointCloud2& cloud, const std::string& field_name)
+{
+  return getPointCloud2FieldIndex(cloud, field_name) != -1;
 }
 
   ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/sensor_msgs/include/sensor_msgs/point_field_conversion.h
+++ b/sensor_msgs/include/sensor_msgs/point_field_conversion.h
@@ -56,7 +56,7 @@
   */
 namespace sensor_msgs{
   /*!
-   * \Enum to type mapping.
+   * \brief Enum to type mapping.
    */
   template<int> struct pointFieldTypeAsType {};
   template<> struct pointFieldTypeAsType<sensor_msgs::PointField::INT8>    { typedef int8_t   type; };
@@ -69,7 +69,7 @@ namespace sensor_msgs{
   template<> struct pointFieldTypeAsType<sensor_msgs::PointField::FLOAT64> { typedef double   type; };
   
   /*!
-   * \Type to enum mapping.
+   * \brief Type to enum mapping.
    */
   template<typename T> struct typeAsPointFieldType {};
   template<> struct typeAsPointFieldType<int8_t>   { static const uint8_t value = sensor_msgs::PointField::INT8;    };
@@ -82,8 +82,8 @@ namespace sensor_msgs{
   template<> struct typeAsPointFieldType<double>   { static const uint8_t value = sensor_msgs::PointField::FLOAT64; };
  
   /*!
-   * \Type names of the PointField data type.
-   * @param field_name Type name for a dynamic type initialization in the pointfield
+   * \brief Type names of the PointField data type.
+   * \param field_name Type name for a dynamic type initialization in the pointfield
    */
   inline int getPointFieldTypeFromString(const std::string& field_name){
     if(field_name == "int8")    return sensor_msgs::PointField::INT8;
@@ -100,8 +100,8 @@ namespace sensor_msgs{
   }
 
   /*!
-   * Return the string name of a datatype (which is an enum of sensor_msgs::PointField::)
-   * @param datatype one of the enums of sensor_msgs::PointField::
+   * \brief Returns the string name of a datatype (which is an enum of sensor_msgs::PointField::)
+   * \param datatype one of the enums of sensor_msgs::PointField::
   */
   inline const std::string getPointFieldNameFromType(const int datatype)
   {
@@ -128,8 +128,8 @@ namespace sensor_msgs{
     }
   }
   /*!
-   * Return the size of a datatype (which is an enum of sensor_msgs::PointField::) in bytes
-   * @param datatype one of the enums of sensor_msgs::PointField::
+   * \brief Returns the size of a datatype (which is an enum of sensor_msgs::PointField::) in bytes
+   * \param datatype one of the enums of sensor_msgs::PointField::
   */
   inline int sizeOfPointField(int datatype)
   {
@@ -157,7 +157,7 @@ namespace sensor_msgs{
   }
 
   /*!
-   * \Converts a value at the given pointer position, interpreted as the datatype
+   * \brief Converts a value at the given pointer position, interpreted as the datatype
    *  specified by the given template argument point_field_type, to the given
    *  template type T and returns it.
    * \param data_ptr            pointer into the point cloud 2 buffer
@@ -171,7 +171,7 @@ namespace sensor_msgs{
     }
   
   /*!
-   * \Converts a value at the given pointer position interpreted as the datatype
+   * \brief Converts a value at the given pointer position interpreted as the datatype
    *  specified by the given datatype parameter to the given template type and returns it.
    * \param data_ptr    pointer into the point cloud 2 buffer
    * \param datatype    sensor_msgs::PointField datatype value
@@ -200,7 +200,7 @@ namespace sensor_msgs{
     }
 
   /*!
-   * \Inserts a given value at the given point position interpreted as the datatype
+   * \brief Inserts a given value at the given point position interpreted as the datatype
    *  specified by the template argument point_field_type.
    * \param data_ptr            pointer into the point cloud 2 buffer
    * \param value               the value to insert
@@ -214,7 +214,7 @@ namespace sensor_msgs{
     }
 
   /*!
-   * \Inserts a given value at the given point position interpreted as the datatype
+   * \brief Inserts a given value at the given point position interpreted as the datatype
    *  specified by the given datatype parameter.
    * \param data_ptr    pointer into the point cloud 2 buffer
    * \param datatype    sensor_msgs::PointField datatype value

--- a/sensor_msgs/include/sensor_msgs/point_field_conversion.h
+++ b/sensor_msgs/include/sensor_msgs/point_field_conversion.h
@@ -83,8 +83,9 @@ namespace sensor_msgs{
  
   /*!
    * \Type names of the PointField data type.
+   * @param field_name Type name for a dynamic type initialization in the pointfield
    */
-  int getPointFieldTypeFromString(const std::string field_name){
+  inline int getPointFieldTypeFromString(const std::string& field_name){
     if(field_name == "int8")    return sensor_msgs::PointField::INT8;
     if(field_name == "uint8")   return sensor_msgs::PointField::UINT8;
     if(field_name == "int16")   return sensor_msgs::PointField::INT16;
@@ -98,7 +99,36 @@ namespace sensor_msgs{
     return -1;
   }
 
-  /** Return the size of a datatype (which is an enum of sensor_msgs::PointField::) in bytes
+  /*!
+   * Return the string name of a datatype (which is an enum of sensor_msgs::PointField::)
+   * @param datatype one of the enums of sensor_msgs::PointField::
+  */
+  inline const std::string getPointFieldNameFromType(const int datatype)
+  {
+    switch(datatype){
+      case sensor_msgs::PointField::INT8:
+        return "int8";
+      case sensor_msgs::PointField::UINT8:
+        return "uint8";
+      case sensor_msgs::PointField::INT16:
+        return "int16";
+      case sensor_msgs::PointField::UINT16:
+        return "uint16";
+      case sensor_msgs::PointField::INT32:
+        return "int32";
+      case sensor_msgs::PointField::UINT32:
+        return "uint32";
+      case sensor_msgs::PointField::FLOAT32:
+        return "float32";
+      case sensor_msgs::PointField::FLOAT64:
+        return "float64";
+      default:
+        std::cerr << "unknown datatype with the number: " << datatype;
+        return "";
+    }
+  }
+  /*!
+   * Return the size of a datatype (which is an enum of sensor_msgs::PointField::) in bytes
    * @param datatype one of the enums of sensor_msgs::PointField::
   */
   inline int sizeOfPointField(int datatype)

--- a/sensor_msgs/include/sensor_msgs/point_field_conversion.h
+++ b/sensor_msgs/include/sensor_msgs/point_field_conversion.h
@@ -84,7 +84,7 @@ namespace sensor_msgs{
   /*!
    * \Type names of the PointField data type.
    */
-  int getPointFieldTypeFromString(std::string field_name){
+  int getPointFieldTypeFromString(const std::string field_name){
     if(field_name == "int8")    return sensor_msgs::PointField::INT8;
     if(field_name == "uint8")   return sensor_msgs::PointField::UINT8;
     if(field_name == "int16")   return sensor_msgs::PointField::INT16;
@@ -94,9 +94,36 @@ namespace sensor_msgs{
     if(field_name == "float32") return sensor_msgs::PointField::FLOAT32;
     if(field_name == "float64") return sensor_msgs::PointField::FLOAT64;
     
-    ROS_ERROR_STREAM("Unknown type: \"" << field_name << "\"!");
-    ROS_ERROR_STREAM("Supported types are: int8, uint8, int16, uint16, int32, uint32, float32, float64"); 
+    std::cerr << "Unknown type: \"" << field_name << "\"! Supported types are: int8, uint8, int16, uint16, int32, uint32, float32, float64" << std::endl; 
     return -1;
+  }
+
+  /** Return the size of a datatype (which is an enum of sensor_msgs::PointField::) in bytes
+   * @param datatype one of the enums of sensor_msgs::PointField::
+  */
+  inline int sizeOfPointField(int datatype)
+  {
+      switch(datatype){
+        case sensor_msgs::PointField::INT8:
+          return sizeof( pointFieldTypeAsType<sensor_msgs::PointField::INT8>::type );
+        case sensor_msgs::PointField::UINT8:
+          return sizeof( pointFieldTypeAsType<sensor_msgs::PointField::UINT8>::type );
+        case sensor_msgs::PointField::INT16:
+          return sizeof( pointFieldTypeAsType<sensor_msgs::PointField::INT16>::type );
+        case sensor_msgs::PointField::UINT16:
+          return sizeof( pointFieldTypeAsType<sensor_msgs::PointField::UINT16>::type );
+        case sensor_msgs::PointField::INT32:
+          return sizeof( pointFieldTypeAsType<sensor_msgs::PointField::INT32>::type );
+        case sensor_msgs::PointField::UINT32:
+          return sizeof( pointFieldTypeAsType<sensor_msgs::PointField::UINT32>::type );
+        case sensor_msgs::PointField::FLOAT32:
+          return sizeof( pointFieldTypeAsType<sensor_msgs::PointField::FLOAT32>::type );
+        case sensor_msgs::PointField::FLOAT64:
+          return sizeof( pointFieldTypeAsType<sensor_msgs::PointField::FLOAT64>::type );
+        default:
+          std::cerr << "unknown datatype with the number: " << datatype;
+          return -1;
+      }
   }
 
   /*!

--- a/sensor_msgs/include/sensor_msgs/point_field_conversion.h
+++ b/sensor_msgs/include/sensor_msgs/point_field_conversion.h
@@ -46,6 +46,8 @@
 #ifndef SENSOR_MSGS_POINT_FIELD_CONVERSION_H
 #define SENSOR_MSGS_POINT_FIELD_CONVERSION_H
 
+#include<string>
+
 /** 
   * \brief  This file provides a type to enum mapping for the different
   *         PointField types and methods to read and write in 
@@ -79,6 +81,24 @@ namespace sensor_msgs{
   template<> struct typeAsPointFieldType<float>    { static const uint8_t value = sensor_msgs::PointField::FLOAT32; };
   template<> struct typeAsPointFieldType<double>   { static const uint8_t value = sensor_msgs::PointField::FLOAT64; };
  
+  /*!
+   * \Type names of the PointField data type.
+   */
+  int getPointFieldTypeFromString(std::string field_name){
+    if(field_name == "int8")    return sensor_msgs::PointField::INT8;
+    if(field_name == "uint8")   return sensor_msgs::PointField::UINT8;
+    if(field_name == "int16")   return sensor_msgs::PointField::INT16;
+    if(field_name == "uint16")  return sensor_msgs::PointField::UINT16;
+    if(field_name == "int32")   return sensor_msgs::PointField::INT32;
+    if(field_name == "uint32")  return sensor_msgs::PointField::UINT32;
+    if(field_name == "float32") return sensor_msgs::PointField::FLOAT32;
+    if(field_name == "float64") return sensor_msgs::PointField::FLOAT64;
+    
+    ROS_ERROR_STREAM("Unknown type: \"" << field_name << "\"!");
+    ROS_ERROR_STREAM("Supported types are: int8, uint8, int16, uint16, int32, uint32, float32, float64"); 
+    return -1;
+  }
+
   /*!
    * \Converts a value at the given pointer position, interpreted as the datatype
    *  specified by the given template argument point_field_type, to the given


### PR DESCRIPTION
This enhancement enables a dynamic creation of sensor_msgs::PointCloud2 messages with dynamic point fields at creation time of the cloud. This means a node or driver providing sensor_msgs::PointCloud2 clouds can now publish  configurable clouds. That is useful for devices which provide much extra information to each point in the cloud. With this enhancement, e.g. the user of a high resolution laser scanner, could configure which extra information should be published within the cloud. This is useful to only publish necessary information and to keep the network communication load smaller.

With the method `bool PointCloud2Modifier::addPointCloud2Field(std::string name, std::string datatype)` it is now possible to dynamically add fields if a field was enabled in the config.