### PR TITLE
Added equidistant distortion model const

### DIFF
--- a/sensor_msgs/include/sensor_msgs/distortion_models.h
+++ b/sensor_msgs/include/sensor_msgs/distortion_models.h
@@ -44,6 +44,7 @@ namespace sensor_msgs
   {
     const std::string PLUMB_BOB = "plumb_bob";
     const std::string RATIONAL_POLYNOMIAL = "rational_polynomial";
+    const std::string EQUIDISTANT = "equidistant";
   }
 }
 


### PR DESCRIPTION
Adds a new distortion model to the const definitions for fisheye cameras. Used in the following PR in vision_opencv/image_geometry to incorporate fisheye rectification into the standard pipeline:
https://github.com/ros-perception/vision_opencv/pull/184