### PR TITLE
Add polygon with 64bit precision

### DIFF
--- a/geometry_msgs/CMakeLists.txt
+++ b/geometry_msgs/CMakeLists.txt
@@ -17,6 +17,8 @@ add_message_files(
   PointStamped.msg
   Polygon.msg
   PolygonStamped.msg
+  Polygon64.msg
+  Polygon64Stamped.msg
   Pose2D.msg
   Pose.msg
   PoseArray.msg

--- a/geometry_msgs/msg/Polygon64.msg
+++ b/geometry_msgs/msg/Polygon64.msg
@@ -1,0 +1,2 @@
+#A specification of a polygon where the first and last points are assumed to be connected (64 bits of precision)
+Point[] points

--- a/geometry_msgs/msg/Polygon64Stamped.msg
+++ b/geometry_msgs/msg/Polygon64Stamped.msg
@@ -1,0 +1,3 @@
+# This represents a Polygon (64 bits of precision) with reference coordinate frame and timestamp
+Header header
+Polygon64 polygon


### PR DESCRIPTION
There is no polygon with 64 bit precision, this adds a Polygon64 and Polygon64Stamped. 

Ideally, the standard naming conventions should be maintained, where Polygon.msg has 64-bit, and Polygon32.msg has 32-bit precision, but that would change the message definition and is more likely to break dependent code.