### PR TITLE
Return default value to prevent missing return warning.

### DIFF
--- a/sensor_msgs/include/sensor_msgs/point_field_conversion.h
+++ b/sensor_msgs/include/sensor_msgs/point_field_conversion.h
@@ -120,6 +120,7 @@ namespace sensor_msgs{
         case sensor_msgs::PointField::FLOAT64:
           return readPointCloud2BufferValue<sensor_msgs::PointField::FLOAT64, T>(data_ptr);
       }
+      return T();
     }
 
   /*!

--- a/sensor_msgs/include/sensor_msgs/point_field_conversion.h
+++ b/sensor_msgs/include/sensor_msgs/point_field_conversion.h
@@ -120,6 +120,7 @@ namespace sensor_msgs{
         case sensor_msgs::PointField::FLOAT64:
           return readPointCloud2BufferValue<sensor_msgs::PointField::FLOAT64, T>(data_ptr);
       }
+      // This should never be reached, but return statement added to avoid compiler warning. (#84)
       return T();
     }
 


### PR DESCRIPTION
This addresses #84.

Original suggested fix was to both return the default value and add a `ROS_BREAK()`, however the latter would require modifying the package dependencies for code is never reached. This fix returns the default value of `T` to silence warnings when compiling with clang, since this part of the code is never reached the behaviour is identical.