### PR TITLE
Revert "actionlib_msgs: add_action_files takes absolute paths for DIRECTORY a…"

### DIFF
--- a/actionlib_msgs/cmake/actionlib_msgs-extras.cmake.em
+++ b/actionlib_msgs/cmake/actionlib_msgs-extras.cmake.em
@@ -21,9 +21,8 @@ macro(add_action_files)
     set(ARG_DIRECTORY "action")
   endif()
 
-  set(ACTION_DIR "${ARG_DIRECTORY}")
-  if(NOT IS_ABSOLUTE "${ACTION_DIR}")
-    set(ACTION_DIR "${CMAKE_CURRENT_SOURCE_DIR}/${ACTION_DIR}")
+  if(NOT IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY})
+    message(FATAL_ERROR "add_action_files() directory not found: ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY}")
   endif()
 
   # if FILES are not passed search action files in the given directory
@@ -31,10 +30,10 @@ macro(add_action_files)
   set(_argv ${ARGV})
   list(FIND _argv "FILES" _index)
   if(_index EQUAL -1)
-    file(GLOB ARG_FILES RELATIVE "${ACTION_DIR}" "${ACTION_DIR}/*.action")
+    file(GLOB ARG_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY}" "${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY}/*.action")
     list(SORT ARG_FILES)
   endif()
-  _prepend_path(${ACTION_DIR} "${ARG_FILES}" FILES_W_PATH)
+  _prepend_path(${CMAKE_CURRENT_SOURCE_DIR}/${ARG_DIRECTORY} "${ARG_FILES}" FILES_W_PATH)
 
   list(APPEND ${PROJECT_NAME}_ACTION_FILES ${FILES_W_PATH})
   foreach(file ${FILES_W_PATH})
@@ -42,11 +41,7 @@ macro(add_action_files)
   endforeach()
 
   if(NOT ARG_NOINSTALL)
-    # ensure that destination variables are initialized
-    catkin_destinations()
-
-    install(FILES ${FILES_W_PATH}
-      DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/${ARG_DIRECTORY})
+    install(FILES ${FILES_W_PATH} DESTINATION share/${PROJECT_NAME}/${ARG_DIRECTORY})
   endif()
 
   foreach(actionfile ${FILES_W_PATH})
@@ -78,7 +73,7 @@ macro(add_action_files)
     endif()
 
     add_message_files(
-      DIRECTORY ${MESSAGE_DIR}
+      BASE_DIR ${MESSAGE_DIR}
       FILES ${OUTPUT_FILES})
   endforeach()
 endmacro()

--- a/actionlib_msgs/package.xml
+++ b/actionlib_msgs/package.xml
@@ -16,7 +16,6 @@
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 
-  <build_depend version_gte="0.5.4">genmsg</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
 


### PR DESCRIPTION
Reverts ros/common_msgs#96

Fixes #120 

@mrjogo I'm reverting this due to the issue raised in #120 

I've confirmed that this is a problem for tf2_msgs when built on top of this commit. https://gist.github.com/tfoote/d844509cd2d67484873ea3321bd6b275

I'm going to roll this back as I'd like to get a release out soon. A replacement for #96 with a fix for this would be appreciated.