### PR TITLE
included missing import for the read_points_list method

### DIFF
--- a/sensor_msgs/src/sensor_msgs/point_cloud2.py
+++ b/sensor_msgs/src/sensor_msgs/point_cloud2.py
@@ -40,13 +40,13 @@ Serialization of sensor_msgs.PointCloud2 messages.
 Author: Tim Field
 """
 
+from collections import namedtuple
 import ctypes
 import math
 import struct
 
 import roslib.message
 from sensor_msgs.msg import PointCloud2, PointField
-from collections import namedtuple
 
 _DATATYPES = {}
 _DATATYPES[PointField.INT8]    = ('b', 1)

--- a/sensor_msgs/src/sensor_msgs/point_cloud2.py
+++ b/sensor_msgs/src/sensor_msgs/point_cloud2.py
@@ -46,6 +46,7 @@ import struct
 
 import roslib.message
 from sensor_msgs.msg import PointCloud2, PointField
+from collections import namedtuple
 
 _DATATYPES = {}
 _DATATYPES[PointField.INT8]    = ('b', 1)


### PR DESCRIPTION
The read_points_list method is currently broken since the import of namedtuple is missing.

Please include this in all current branches

@v4hn