### PR TITLE
Proposed UpperTriangularCovariance message

### DIFF
--- a/geometry_msgs/msg/UpperTriangularCovariance.msg
+++ b/geometry_msgs/msg/UpperTriangularCovariance.msg
@@ -1,0 +1,25 @@
+# Row-major representation of 6x6 velocity cross-covariance matrix in an upper right triangular
+# Order: vx, vy, vz, rotation rate about X axis, rotation rate about Y axis, rotation rate about Z axis
+
+# If linear velocity covariance invalid/unknown, first cell is NaN
+# If angular velocity covariance invalid/unknown, 16th cell is NaN
+
+# Covariance matrix index constants
+uint8 MATRIX_LINEAR_X_VARIANCE=0
+uint8 MATRIX_LINEAR_Y_VARIANCE=6
+uint8 MATRIX_LINEAR_Z_VARIANCE=11
+uint8 MATRIX_ANGULAR_X_VARIANCE=15
+uint8 MATRIX_ANGULAR_Y_VARIANCE=18
+uint8 MATRIX_ANGULAR_Z_VARIANCE=20
+
+# Convenient aliases for common names.
+uint8 MATRIX_ROLL_VARIANCE=15
+uint8 MATRIX_PITCH_VARIANCE=18
+uint8 MATRIX_YAW_VARIANCE=20
+
+# Constants to index to cells to check for invalid/unknown data
+uint8 MATRIX_LINEAR_VALID_CELL=0
+uint8 MATRIX_ANGULAR_VALID_CELL=15
+
+# Raw Storage
+float32[21] covariance


### PR DESCRIPTION
In most of our messages right now we transport covariance matrices as 36 64bit numbers.
This reduces it to only 21 as well as reducing the floating point representation to 32bits.
This makes it take up only 29% as much space on the wire and in memory.
The precision of the floating point values is unlikely to be important as the value is designed to capture the magnitude of the uncertainty so the 32bit representation should be fine.
And the covariance matrices are symmetric so the other half of the matrix is redundant.

With some helper methods to convert to and from full matricies in common linear math libraries it should not effect workflows.
And by standardizing this common checks can also be performed in a standardized way instead of the current ad-hoc method in each implementation.

This has been inspired by the URT covariance matrix implementation used in the vehicle_odometry.msg recently adopted by PX4: https://github.com/PX4/Firmware/pull/9895/files#diff-0f57b02da78e5e981838d756f46d7462R56

This is intended to be used mostly as a submessage for an evolution of https://github.com/ros/common_msgs/pull/87