### PR TITLE
Added AnchorScan.msg

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -11,6 +11,7 @@ include_directories(include)
 add_message_files(
   DIRECTORY msg
   FILES
+  AnchorScan.msg
   BatteryState.msg
   CameraInfo.msg
   ChannelFloat32.msg


### PR DESCRIPTION
This is a message to hold the fixed anchors' (UWB sensors) information at known coordinates and Time Difference of Arrival (TDOA) values. The indoor positioning systems developed using UWB signals include multiple sensors that transmit UWB signals in an environment. Calculations such as position, anchor selection etc. are made by using TDOA measurements from these sensors and coordinate information of the sensors.  With the defined AnchorScan message, it allows the publish of this information from the sensors via any developed firmware.