### PR TITLE
Add Microwave radiation type.

### DIFF
--- a/sensor_msgs/msg/Range.msg
+++ b/sensor_msgs/msg/Range.msg
@@ -15,6 +15,7 @@ Header header           # timestamp in the header is the time the ranger
 # If you want a value added to this list, send an email to the ros-users list
 uint8 ULTRASOUND=0
 uint8 INFRARED=1
+uint8 MICROWAVE=2
 
 uint8 radiation_type    # the type of radiation used by the sensor
                         # (sound, IR, etc) [enum]


### PR DESCRIPTION
This PR adds `MICROWAVE` as a radiation type to range sensors. For example to capture radar altimeters such as [uLanding](https://aerotenna.readme.io/docs/what-is-%CE%BClanding). 