### PR TITLE
Add feedback to GetMap.action

### DIFF
--- a/nav_msgs/action/GetMap.action
+++ b/nav_msgs/action/GetMap.action
@@ -2,4 +2,4 @@
 ---
 nav_msgs/OccupancyGrid map
 ---
-# no feedback
+nav_msgs/OccupancyGrid progress_map


### PR DESCRIPTION
The `GetMap.action` now only contains a result. This PR extends the action with feedback which is useful for getting progress updates while doing mapping.