### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/actionlib_msgs/CMakeLists.txt
+++ b/actionlib_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(actionlib_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)

--- a/common_msgs/CMakeLists.txt
+++ b/common_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(common_msgs)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/diagnostic_msgs/CMakeLists.txt
+++ b/diagnostic_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(diagnostic_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)

--- a/geometry_msgs/CMakeLists.txt
+++ b/geometry_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(geometry_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)

--- a/nav_msgs/CMakeLists.txt
+++ b/nav_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(nav_msgs)
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs message_generation std_msgs actionlib_msgs)

--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(sensor_msgs)
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs message_generation std_msgs)

--- a/shape_msgs/CMakeLists.txt
+++ b/shape_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(shape_msgs)
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs message_generation std_msgs)

--- a/stereo_msgs/CMakeLists.txt
+++ b/stereo_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(stereo_msgs)
 
 find_package(catkin REQUIRED COMPONENTS sensor_msgs message_generation std_msgs)

--- a/trajectory_msgs/CMakeLists.txt
+++ b/trajectory_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(trajectory_msgs)
 
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs geometry_msgs)

--- a/visualization_msgs/CMakeLists.txt
+++ b/visualization_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(visualization_msgs)
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs message_generation std_msgs)


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building this package in Debian Buster and Ubuntu Focal.

Same as ros/catkin#1052