### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/sensor_msgs/package.xml
+++ b/sensor_msgs/package.xml
@@ -1,4 +1,8 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>sensor_msgs</name>
   <version>1.12.7</version>
   <description>
@@ -11,14 +15,16 @@
   <url>http://ros.org/wiki/sensor_msgs</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>geometry_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>std_msgs</run_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>rosbag</test_depend>
   <test_depend>rosunit</test_depend>

--- a/sensor_msgs/setup.py
+++ b/sensor_msgs/setup.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
On Debian Buster and Ubuntu Focal [distutils has been split to a separate package](https://packages.debian.org/buster/python3-setuptools). With https://github.com/ros/catkin/pull/1048 catkin will prefer to use `setuptools` instead of `distutils`. This PR switches to `setuptools` to match catkin's preference. It uses conditional dependencies so it still works when `ROS_PYTHON_VERSION` is 2 to enable the target branch to be released to earlier ROS distros than Noetic.


I also removed shebangs from the setup.py since [`setup.py` isn't meant to be executed directly](http://docs.ros.org/melodic/api/catkin/html/user_guide/setup_dot_py.html)