### PR TITLE
YUV420 support

### DIFF
--- a/sensor_msgs/include/sensor_msgs/image_encodings.h
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.h
@@ -99,6 +99,7 @@ namespace sensor_msgs
     // This is the UYVY version of YUV422 codec http://www.fourcc.org/yuv.php#UYVY
     // with an 8-bit depth
     const std::string YUV422="yuv422";
+    const std::string YUV420="yuv420";
 
     // Prefixes for abstract image encodings
     const std::string ABSTRACT_ENCODING_PREFIXES[] = {
@@ -176,6 +177,9 @@ namespace sensor_msgs
       if (encoding == YUV422)
         return 2;
 
+      if (encoding == YUV420)
+        return 1;
+
       throw std::runtime_error("Unknown encoding " + encoding);
       return -1;
     }
@@ -221,7 +225,7 @@ namespace sensor_msgs
           return atoi(prefix.c_str());  // valid encoding string
       }
 
-      if (encoding == YUV422)
+      if (encoding == YUV422 || encoding == YUV420)
         return 8;
 
       throw std::runtime_error("Unknown encoding " + encoding);

--- a/sensor_msgs/include/sensor_msgs/image_encodings.h
+++ b/sensor_msgs/include/sensor_msgs/image_encodings.h
@@ -99,6 +99,7 @@ namespace sensor_msgs
     // This is the UYVY version of YUV422 codec http://www.fourcc.org/yuv.php#UYVY
     // with an 8-bit depth
     const std::string YUV422="yuv422";
+    // YUV420 format, 12 bits per pixel
     const std::string YUV420="yuv420";
 
     // Prefixes for abstract image encodings


### PR DESCRIPTION
This PR adds support for YUV420 (or I420) images.

I420 is the most common YUV format and is adopted by most Image Sensor Processor (ISP) chips, specifically this was implemented to work with [gstreamer based v4l plugins](https://answers.ros.org/question/343864/how-can-i-publish-i420-image-data-as-sensor_msgsimage-image-transport-plugin/?answer=360789#post-id-360789)

I420 consists in 12 bits per pixel, which is implemented in OpenCV as a cv::Mat with one 8 bit channel with 1.5x the number of rows of the actual image.