### PR TITLE
[sensor_msgs] add PanoramaInfo.msg and update CMakeLists.txt

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -30,6 +30,7 @@ add_message_files(
   MultiEchoLaserScan.msg
   NavSatFix.msg
   NavSatStatus.msg
+  PanoramaInfo.msg
   PointCloud.msg
   PointCloud2.msg
   PointField.msg

--- a/sensor_msgs/msg/PanoramaInfo.msg
+++ b/sensor_msgs/msg/PanoramaInfo.msg
@@ -1,0 +1,32 @@
+# This message defines meta information for a panorama image. It should
+# be in the same namespace with a image topic.
+
+#######################################################################
+#                     Image acquisition info                          #
+#######################################################################
+
+# Time of image acquisition, panorama image coordinate frame ID
+Header header    # Header timestamp should be acquisition time of image
+                 # Header frame_id should be frame of panorama image
+                 # origin of frame should be projection center
+                 # +x should point to the front of a sphere
+                 # +z should point to the top of a sphere
+
+#######################################################################
+#                      Image projection info                          #
+#######################################################################
+
+# The projection model from spherical view to a flat image.
+# E.g. "Equirectangular"
+string projection_model
+
+#######################################################################
+#                     Field of View Parameters                         #
+#######################################################################
+
+# Specifying field of view of a panorama image.
+# theta, phi are azimuthal and polar angle of spherical coordinate.
+float64 theta_min
+float64 theta_max
+float64 phi_min
+float64 phi_max


### PR DESCRIPTION
Add PanoramaInfo.msg to represent meta-information about panoramic images.

We are using panoramic images generated from fisher eye images.
- https://github.com/jsk-ros-pkg/jsk_recognition/pull/2555
- https://jsk-docs.readthedocs.io/projects/jsk_recognition/en/latest/jsk_perception/nodes/fisheye_to_panorama.html?highlight=fisheye
- https://jsk-docs.readthedocs.io/projects/jsk_recognition/en/latest/jsk_perception/nodes/fisheye_stitcher.html?highlight=fisheye

And we are defining a meta-information message of these panoramic images. https://github.com/jsk-ros-pkg/jsk_recognition/pull/2579 
This meta-information is necessary if calculating geometric information from panoramic images.
And I think this is useful for other users of panorama images.

PanoramaInfo.msg contains information below
- header which represents image acqusition information
- projection model information
  + currently, we only use "equirectangular" projection. But there are other kinds of projection model. e.g. [mercator](https://github.com/tu-darmstadt-ros-pkg/image_projection)
- field of view information
  + Panoramic Image does not necessarily have 360 degrees FOV. (e.g. only front side of sphere) So we needs FOV information.

CC: @k-okada 