### PR TITLE
support for cv::omnidir

### DIFF
--- a/sensor_msgs/include/sensor_msgs/distortion_models.h
+++ b/sensor_msgs/include/sensor_msgs/distortion_models.h
@@ -45,6 +45,7 @@ namespace sensor_msgs
     const std::string PLUMB_BOB = "plumb_bob";
     const std::string RATIONAL_POLYNOMIAL = "rational_polynomial";
     const std::string EQUIDISTANT = "equidistant";
+    const std::string OMNIDIRECTIONAL = "omnidirectional";
   }
 }
 


### PR DESCRIPTION
I have found the current fisheye distortion models in ROS to be insufficient for very wide angle lenses.  OpenCV contains an additional calibration method that is capable of modeling catadioptric cameras and fisheye cameras with very wide fields of view.  I am working on implementing that method in vision_opencv and the image_pipeline, but it requires a placeholder entry in sensor_msgs/distortion_models.h.

https://docs.opencv.org/3.4/db/dd2/namespacecv_1_1omnidir.html
https://docs.opencv.org/4.x/dd/d12/tutorial_omnidir_calib_main.html