### PR TITLE
[compat] Remove additional spaces

### DIFF
--- a/geometry_msgs/msg/Twist.msg
+++ b/geometry_msgs/msg/Twist.msg
@@ -1,3 +1,3 @@
 # This expresses velocity in free space broken into its linear and angular parts.
-Vector3  linear
-Vector3  angular
+Vector3 linear
+Vector3 angular

--- a/sensor_msgs/msg/Temperature.msg
+++ b/sensor_msgs/msg/Temperature.msg
@@ -1,8 +1,8 @@
- # Single temperature reading.
+# Single temperature reading.
 
- Header header           # timestamp is the time the temperature was measured
+Header header           # timestamp is the time the temperature was measured
                          # frame_id is the location of the temperature reading
 
- float64 temperature     # Measurement of the Temperature in Degrees Celsius
+float64 temperature     # Measurement of the Temperature in Degrees Celsius
 
- float64 variance        # 0 is interpreted as variance unknown
+float64 variance        # 0 is interpreted as variance unknown


### PR DESCRIPTION
This is not just a cosmetic change, some proprietary platforms' ROS integration like dSpace's Simulink ROS integration have weird parsers that can't handle these kinds of inconsistencies and will throw obscure error messages.

A merge would be kindly appreciated. Thanks!