### PR TITLE
Add Lead-Acid battery type

### DIFF
--- a/sensor_msgs/msg/BatteryState.msg
+++ b/sensor_msgs/msg/BatteryState.msg
@@ -30,6 +30,7 @@ uint8 POWER_SUPPLY_TECHNOLOGY_LIPO = 3
 uint8 POWER_SUPPLY_TECHNOLOGY_LIFE = 4
 uint8 POWER_SUPPLY_TECHNOLOGY_NICD = 5
 uint8 POWER_SUPPLY_TECHNOLOGY_LIMN = 6
+uint8 POWER_SUPPLY_TECHNOLOGY_PB = 7
 
 Header  header
 float32 voltage          # Voltage in Volts (Mandatory)


### PR DESCRIPTION
Lead acid battery types are not in the power supply technology list.