### PR TITLE
sensor_msgs/CompressedImage: updated description of format field

### DIFF
--- a/sensor_msgs/msg/CompressedImage.msg
+++ b/sensor_msgs/msg/CompressedImage.msg
@@ -8,6 +8,34 @@ Header header        # Header timestamp should be acquisition time of image
                      # +z should point into to plane of the image
 
 string format        # Specifies the format of the data
-                     #   Acceptable values:
-                     #     jpeg, png
+                     # Acceptable values differ by the image transport used:
+                     # - compressed_image_transport:
+                     #     ORIG_PIXFMT; CODEC compressed [COMPRESSED_PIXFMT]
+                     #   where:
+                     #   - ORIG_PIXFMT is pixel format of the raw image, i.e.
+                     #     the content of sensor_msgs/Image/encoding with
+                     #     values from include/sensor_msgs/image_encodings.h
+                     #   - CODEC is one of [jpeg, png]
+                     #   - COMPRESSED_PIXFMT is only appended for color images
+                     #     and is the pixel format used by the compression
+                     #     algorithm. Valid values for jpeg encoding are:
+                     #     [bgr8, rgb8]. Valid values for png encoding are:
+                     #     [bgr8, rgb8, bgr16, rgb16].
+                     #   If the field is empty or does not correspond to the
+                     #   above pattern, the image is treated as bgr8 or mono8
+                     #   jpeg image (depending on the number of channels).
+                     # - compressed_depth_image_transport:
+                     #     ORIG_PIXFMT; compressedDepth CODEC
+                     #   where:
+                     #   - ORIG_PIXFMT is pixel format of the raw image, i.e.
+                     #     the content of sensor_msgs/Image/encoding with
+                     #     values from include/sensor_msgs/image_encodings.h
+                     #     It is usually one of [16UC1, 32FC1].
+                     #   - CODEC is one of [png, rvl]
+                     #   If the field is empty or does not correspond to the
+                     #   above pattern, the image is treated as png image.
+                     # - Other image transports can store whatever values they
+                     #   need for successful decoding of the image. Refer to
+                     #   documentation of the other transports for details.
+
 uint8[] data         # Compressed image buffer


### PR DESCRIPTION
The description of the `format` field has long been outdated. This PR fixes it to be up-to-date with the core image_transport plugins.

This PR only changes comments and whitespace, so it doesn't change the MD5 sum of the message.

Fixes https://github.com/ros-perception/image_transport_plugins/issues/56 .